### PR TITLE
Make GitHub detect *.nr as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.nr linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect `.nr` as Forth.  It certainly looks very much like Forth!

Also, I challenge you to write more of North in North itself. :-)

Thanks!
